### PR TITLE
Support for RUser 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem 'rails-timeago'
 
 gem 'faker'
 gem 'populator'
-gem 'ruser'
+gem 'ruser', '~> 3.0'
 gem 'timecop' #used to populate
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,9 +113,9 @@ GEM
     griddler (1.1.0)
       htmlentities
       rails (>= 3.2.0)
-    griddler-cloudmailin (0.0.1)
-      griddler
     griddler-mailgun (1.0.2)
+      griddler
+    griddler-mailin (0.0.1)
       griddler
     griddler-mandrill (1.0.2)
       griddler
@@ -123,7 +123,6 @@ GEM
       griddler
     griddler-sendgrid (0.0.1)
       griddler
-    hashie (3.4.1)
     hike (1.2.3)
     hitimes (1.2.2)
     htmlentities (4.3.3)
@@ -273,10 +272,7 @@ GEM
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
     ruby-progressbar (1.7.5)
-    ruser (2.0.1)
-      hashie (~> 3.3)
-      multi_json (~> 1.10)
-      rest-client (~> 1.7)
+    ruser (3.0.0)
     sass (3.4.13)
     sass-rails (5.0.1)
       railties (>= 4.0.0, < 5.0)
@@ -366,8 +362,8 @@ DEPENDENCIES
   globalize-versioning (~> 0.1.0)
   gravtastic
   griddler
-  griddler-cloudmailin
   griddler-mailgun
+  griddler-mailin
   griddler-mandrill
   griddler-postmark
   griddler-sendgrid
@@ -399,7 +395,7 @@ DEPENDENCIES
   rdiscount
   route_translator
   rspec
-  ruser
+  ruser (~> 3.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   shoulda
@@ -414,3 +410,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.11.2

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -17,28 +17,28 @@ namespace :db do
   end
 
   # Add Support Team
-  company = RUser.new.first
+  company = RUser.new
   company_name = "#{Faker::Hacker.noun} #{Faker::Hacker.ingverb} #{company_type}"
 
   number_support_team.times do
-    user = RUser.new.first
+    user = RUser.new
     u = User.new
-    u.name = "#{user.name.first_name} #{user.name.last_name}"
+    u.name = "#{user.first_name} #{user.last_name}"
     u.email = user.email
     u.login = user.username
     u.password = '12345678'
     u.admin = true
     u.role = 'admin'
     u.company = company_name
-    u.street = company.location.street
-    u.city = company.location.city
-    u.state = company.location.state
-    u.zip = company.location.zip
+    u.street = company.street
+    u.city = company.city
+    u.state = company.state
+    u.zip = company.postal
     u.work_phone = company.phone
     u.cell_phone = user.cell
-    u.thumbnail = user.picture.thumbnail
-    u.medium_image = user.picture.medium
-    u.large_image = user.picture.large
+    u.thumbnail = user.profile_thumbnail_url
+    u.medium_image = user.profile_medium_url
+    u.large_image = user.profile_large_url
     u.save
 
     puts "Created Agent: #{u.name}"
@@ -47,22 +47,22 @@ namespace :db do
   # Create users with avatars
   number_users.times do
 
-    user = RUser.new.first
+    user = RUser.new
     u = User.new
-    u.name = "#{user.name.first_name} #{user.name.last_name}"
+    u.name = "#{user.first_name} #{user.last_name}"
     u.email = user.email
     u.login = user.username
     u.password = '12345678'
     u.company = "#{Faker::Hacker.noun} #{Faker::Hacker.ingverb} #{company_type}"
-    u.street = user.location.street
-    u.city = user.location.city
-    u.state = user.location.state
-    u.zip = user.location.zip
+    u.street = user.street
+    u.city = user.city
+    u.state = user.state
+    u.zip = user.postal
     u.work_phone = user.phone
     u.cell_phone = user.cell
-    u.thumbnail = user.picture.thumbnail
-    u.medium_image = user.picture.medium
-    u.large_image = user.picture.large
+    u.thumbnail = user.profile_thumbnail_url
+    u.medium_image = user.profile_medium_url
+    u.large_image = user.profile_large_url
     u.save
 
     puts "Created User: #{user.name}"
@@ -71,17 +71,17 @@ namespace :db do
   # Create users without avatars
   number_users.times do
 
-    user = RUser.new.first
+    user = RUser.new
     u = User.new
-    u.name = "#{user.name.first_name} #{user.name.last_name}"
+    u.name = "#{user.first_name} #{user.last_name}"
     u.email = user.email
     u.login = user.username
     u.password = '12345678'
     u.company = "#{Faker::Hacker.noun} #{Faker::Hacker.ingverb} #{company_type}"
-    u.street = user.location.street
-    u.city = user.location.city
-    u.state = user.location.state
-    u.zip = user.location.zip
+    u.street = user.street
+    u.city = user.city
+    u.state = user.state
+    u.zip = user.postal
     u.work_phone = user.phone
     u.cell_phone = user.cell
     u.save
@@ -121,7 +121,7 @@ namespace :db do
   Category.first.docs.first.save
   Category.first.docs.first.attributes = {title: "Documentació de suport Exemple traduïda al francès" ,body: '', locale: :ca}
   Category.first.docs.first.save
-  
+
   # Create community threads for our users
 
   number_threads.times do


### PR DESCRIPTION
This PR updates Helpy to use [RUser](http://github.com/jtkendall/ruser) 3.0.0 which removes all of it's previous dependencies (Hashie, RestClient, and MultiJson). It also removes the unnecessary `.location.` and `.name.` objects. This also moves to RandomUser API version 0.7 from 0.4.1.