### PR TITLE
Update paper_trail gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,8 @@ gem 'acts-as-taggable-on', '~>3.5'
 
 gem 'kaminari'
 gem 'kaminari-i18n'
-#gem 'globalize', '~> 5.0.0'
-gem 'globalize-versioning', '~> 0.1.0'
+
+gem 'globalize-versioning'
 gem 'globalize-accessors'
 
 gem 'gravtastic'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,9 +238,10 @@ GEM
       json (~> 1.3)
       omniauth-oauth (~> 1.1)
     orm_adapter (0.5.0)
-    paper_trail (3.0.9)
-      activerecord (>= 3.0, < 5.0)
-      activesupport (>= 3.0, < 5.0)
+    paper_trail (4.1.0)
+      activerecord (>= 3.0, < 6.0)
+      activesupport (>= 3.0, < 6.0)
+      request_store (~> 1.1)
     parser (2.3.0.6)
       ast (~> 2.2)
     permalink_fu (1.0.0)
@@ -301,6 +302,7 @@ GEM
     rdiscount (2.1.8)
     rdoc (4.2.1)
       json (~> 1.4)
+    request_store (1.3.0)
     responders (2.1.1)
       railties (>= 4.2.0, < 5.1)
     rest-client (1.8.0)
@@ -469,3 +471,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,11 +119,11 @@ GEM
       activerecord (>= 4.2.0, < 4.3)
     globalize-accessors (0.2.1)
       globalize (~> 5.0, >= 5.0.0)
-    globalize-versioning (0.1.0)
+    globalize-versioning (0.2.0)
       activemodel (>= 3.2.0, < 5)
       activerecord (>= 3.2.0, < 5)
       globalize (>= 3.0.4, < 6)
-      paper_trail (~> 3.0.0)
+      paper_trail (>= 3.0.0, < 5)
     gravtastic (3.2.6)
     griddler (1.2.1)
       htmlentities
@@ -415,7 +415,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   globalize-accessors
-  globalize-versioning (~> 0.1.0)
+  globalize-versioning
   gravtastic
   griddler
   griddler-mailgun

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,9 +6,6 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
-
-  ActiveSupport::Deprecation.silenced = true
-
   # Add more helper methods to be used by all tests here...
   Settings.send_email = true
 end


### PR DESCRIPTION
I envisaged this being a big one, as this project heavily relies on versioning for locale / translation reasons.

The breaking changes involved with `paper_trail` are [well documented](https://github.com/airblade/paper_trail/blob/master/CHANGELOG.md#400-2015-07-30), and don't appear to apply to this codebase.

Sadly, we needed to reference the git repo of `globalize-versioning` because the update is not yet released on RubyGems - [see issue](https://github.com/globalize/globalize-versioning/issues/13).

Updating `paper_trail` is required to facilitate a Rails 5 upgrade.