### PR TITLE
Fix/refactor admin posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,6 +137,9 @@ group :test do
   gem 'rspec'
   gem 'shoulda'
   gem 'factory_girl_rails'
+  gem 'capybara'
+  gem 'selenium-webdriver'
+  gem 'launchy'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,16 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (8.2.1)
+    capybara (2.5.0)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
+    childprocess (0.5.9)
+      ffi (~> 1.0, >= 1.0.11)
     cloudinary (1.1.2)
       aws_cf_signer
       rest-client
@@ -187,6 +195,8 @@ GEM
       kaminari
       rails
     kgio (2.10.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     less (2.6.0)
       commonjs (~> 0.2.7)
     less-rails (2.7.1)
@@ -355,6 +365,7 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.8.1)
       sexp_processor (~> 4.1)
+    rubyzip (1.2.0)
     ruser (3.0.0)
     safe_yaml (1.0.4)
     sass (3.4.21)
@@ -370,6 +381,11 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    selenium-webdriver (2.52.0)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     sexp_processor (4.7.0)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
@@ -428,6 +444,9 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    websocket (1.2.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -443,6 +462,7 @@ DEPENDENCIES
   bullet
   bundler-audit
   byebug
+  capybara
   cloudinary (= 1.1.2)
   config
   daemons
@@ -469,6 +489,7 @@ DEPENDENCIES
   jquery-ui-rails
   kaminari
   kaminari-i18n
+  launchy
   mail_extract
   mailman
   minitest
@@ -497,6 +518,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scss-lint
   sdoc (~> 0.4.0)
+  selenium-webdriver
   shoulda
   spring (~> 1.4.0)
   staccato
@@ -508,6 +530,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.11.2

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -98,7 +98,7 @@ class PostsController < ApplicationController
           redirect_to topic_posts_path(@topic)
         }
         format.js {
-          if current_user.admin?
+          if params[:from] == 'admin' #posted from admin side
             fetch_counts
 
             @posts = @topic.posts.chronologic
@@ -112,7 +112,7 @@ class PostsController < ApplicationController
             end
             render 'admin/ticket'
 
-          else #current_user is a customer
+          else # posted from customer side
             @posts = @topic.posts.ispublic.chronologic.active
             unless @topic.assigned_user_id.nil?
               agent = User.find(@topic.assigned_user_id)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,7 +29,7 @@ class PostsController < ApplicationController
   def index
     @topic = Topic.undeleted.ispublic.where(id: params[:topic_id]).first#.includes(:forum)
     if @topic
-      @posts = @topic.posts.ispublic.active.all.chronologic
+      @posts = @topic.posts.ispublic.active.all.chronologic.includes(:user)
       @post = @topic.posts.new
 
       #@related = Topic.ispublic.by_popularity.front.tagged_with(@topic.tag_list)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -15,7 +15,7 @@
 
 module PostsHelper
 
-  def post_message(post)
+  def post_message(post,admin=false)
 
     case post.kind
     when 'first'
@@ -25,7 +25,7 @@ module PostsHelper
     when 'note'
       message = t(:posted_note, user_name: post.user.name.titleize, default: "posted an internal note...")
     end
-    if user_signed_in? && current_user.admin? && params[:controller] == 'admin'
+    if admin
       content_tag(:span, class: 'btn dropdown-toggle more-important', data: { toggle: 'dropdown'}, aria: {expanded: 'false'}) do
         "#{message} <span class='caret'></span>".html_safe
       end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -62,12 +62,12 @@ module UsersHelper
       unless Cloudinary.config.cloud_name.nil?
         image_tag("http://res.cloudinary.com/#{Cloudinary.config.cloud_name}/image/upload/c_thumb,w_#{size},h_#{size}/#{user.avatar.path}", width: "#{size}px", class: 'img-circle')
       else
-        image_tag('#', data: { name: "#{user.name}", width: "#{size}", height: "#{size}", 'font-size' => '16', 'char-count' => 2}, class: 'profile img-circle')
+        image_tag('', data: { name: "#{user.name}", width: "#{size}", height: "#{size}", 'font-size' => '16', 'char-count' => 2}, class: 'profile img-circle')
       end
     elsif !user.thumbnail.nil?
       image_tag(user.thumbnail, width: "#{size}px", class: 'img-circle')
     else
-      image_tag('#', data: { name: "#{user.name}", width: "#{size}", height: "#{size}", 'font-size' => '16', 'char-count' => 2}, class: 'profile img-circle')
+      image_tag('', data: { name: "#{user.name}", width: "#{size}", height: "#{size}", 'font-size' => '16', 'char-count' => 2}, class: 'profile img-circle')
     end
 
   end

--- a/app/views/admin/_post.html.erb
+++ b/app/views/admin/_post.html.erb
@@ -1,0 +1,36 @@
+<!-- Admin post partial -->
+<div id="post-<%= post.id %>" class="media post-container disallow-post-voting <%= "kind-#{post.kind}" %><%= " inactive" unless post.active? %>">
+	<div class="pull-left">
+		<%= avatar_image(post.user, size=40) %>
+	</div>
+	<div class="media-body media-right">
+		<span class="hidden-sm hidden-md hidden-lg"><%= post.kind == "first" ? last_active_time(post.created_at) : "#{distance_of_time_in_words(post.created_at,post.topic.created_at)} later" %><br/></span>
+		<span id="row-<%= post.id %>"  class="post-menu post-menu-<%= post.id %> btn-group">
+			<%= post_message(post,true) %>
+			<ul class="dropdown-menu dropdown-menu-left" role="menu">
+				<li><%= link_to 'Edit', edit_post_path(post), remote: true %></li>
+				<li><%= link_to 'Turn post into content', new_doc_path(post_id: post.id, lang: I18n.locale) %></li>
+			</ul>
+		</span>
+
+		<span class="last-active posted-at less-important pull-right">
+			<span class="hidden-xs">
+			<%= post.kind == "first" ? last_active_time(post.created_at) : "#{distance_of_time_in_words(post.created_at,post.topic.created_at)} later" %>
+			</span>
+		</span>
+
+		<div id="post-body-<%= post.id %>" class="post-body less-important text-left">
+			<%= simple_format(post.body) -%>
+			<% unless Cloudinary.config.cloud_name.nil? %>
+			<div id="post-images">
+				<ul class="list-inline">
+					<% post.screenshots.each do |screenshot| %>
+						<li><%= link_to cl_image_tag(screenshot.path, { size: '125x125', crop: :fit }), "http://res.cloudinary.com/#{Cloudinary.config.cloud_name}/image/upload/#{screenshot.path}", class: 'screenshot-link' %></li>
+					<% end %>
+				</ul>
+			</div>
+			<% end %>
+		</div>
+
+	</div>
+</div>

--- a/app/views/admin/_ticket.html.erb
+++ b/app/views/admin/_ticket.html.erb
@@ -15,7 +15,7 @@
       Helpy.messages = '<%= j t(:collapsed_messages, count: @posts.count-2) %>';
     </script>
     <div id="posts">
-    <%= render :partial => 'posts/post', :collection => @posts %>
+    <%= render :partial => 'admin/post', :collection => @posts %>
     </div>
 
 
@@ -33,8 +33,10 @@
         <% end %>
 
         <%= hidden_field_tag :client_id %>
+        <%= hidden_field_tag :from, 'admin' %>
         <%= f.text_area :body, :rows => 8, :cols => 160, hide_label: true, placeholder: t(:type_reply, default: "Type your reply, or select from a common message below") %>
         <%= i18n_reply %>
+        <br/>
         <%= f.attachinary_file_field :screenshots unless Cloudinary.config.cloud_name.nil? %>
         <%= f.submit t(:submit_reply), class: 'btn btn-warning' -%>
       <% end -%>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -22,6 +22,7 @@
 <%= favicon_link_tag 'favicon.ico' %>
 <%= cloudinary_js_config %>
 
+<% unless Rails.env.test? %>
 <script data-turbolinks-eval="false">
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -29,3 +30,4 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 ga('create', '<%= Settings.google_analytics_id %>', 'auto');
 </script>
+<% end %>

--- a/app/views/layouts/_login.html.erb
+++ b/app/views/layouts/_login.html.erb
@@ -9,7 +9,7 @@
 
 <hr class="hidden-lg hidden-md"/>
 
-<div class="login-form" class="col-md-6">
+<div class="login-form col-md-6">
 <% else %>
 
 <div class="col-md-12 login-form" data-title="<%= t('devise.sessions.new.sign_in') %>">

--- a/app/views/layouts/_login.html.erb
+++ b/app/views/layouts/_login.html.erb
@@ -9,7 +9,7 @@
 
 <hr class="hidden-lg hidden-md"/>
 
-<div class="col-md-6">
+<div class="login-form" class="col-md-6">
 <% else %>
 
 <div class="col-md-12 login-form" data-title="<%= t('devise.sessions.new.sign_in') %>">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,18 +1,12 @@
+<!-- standard post partial -->
 <div id="post-<%= post.id %>" class="media post-container <%= "kind-#{post.kind}" %><%= post.topic.forum.allow_post_voting? ? "" : " disallow-post-voting" %><%= " inactive" unless post.active? %>">
 	<div class="pull-left">
-		<%#= image_tag(user_avatar(post.user), width: '40px', class: 'media-object img-circle') %>
 		<%= avatar_image(post.user, size=40) %>
 	</div>
 	<div class="media-body media-right">
 		<span class="hidden-sm hidden-md hidden-lg"><%= post.kind == "first" ? last_active_time(post.created_at) : "#{distance_of_time_in_words(post.created_at,post.topic.created_at)} later" %><br/></span>
 		<span id="row-<%= post.id %>"  class="post-menu post-menu-<%= post.id %> btn-group">
 			<%= post_message(post) %>
-			<% if user_signed_in? && current_user.admin? && params[:controller] == 'admin' %>
-				<ul class="dropdown-menu dropdown-menu-left" role="menu">
-					<li><%= link_to 'Edit', edit_post_path(post), remote: true %></li>
-					<li><%= link_to 'Turn post into content', new_doc_path(post_id: post.id, lang: I18n.locale) %></li>
-				</ul>
-			<% end %>
 		</span>
 
 		<span class="last-active posted-at less-important pull-right">
@@ -43,10 +37,9 @@
 			<% end %>
 		</div>
 
-		<% if user_signed_in? && post.kind == 'first' && post.topic.forum.allow_post_voting == true && params[:controller] != 'admin'   %>
+		<% if user_signed_in? && post.kind == 'first' && post.topic.forum.allow_post_voting == true %>
 			<div class="add-form inline-reply">
 			<h4><%= t(:reply) %></h4>
-			<%#= error_messages_for :post -%>
 			<%= bootstrap_form_for :post, :url => topic_posts_path(@topic) do |f| -%>
 			  <%= f.text_area :body, :rows => 4, :cols => 160, label: 'Type your response:' -%></p>
 			  <%= f.hidden_field 'kind', value: 'reply' %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -16,7 +16,7 @@
 		# it will render immediately after the first post, within the partial.
 		%>
 		<% if user_signed_in? && @topic.forum.allow_post_voting == false %>
-		<div class="add-form">
+			<div class="add-form">
 			<h4><%= t(:reply) %></h4>
 			<%#= error_messages_for :post -%>
 			<%= bootstrap_form_for :post, :url => topic_posts_path(@topic) do |f| -%>
@@ -31,7 +31,7 @@
 			</div>
 		<% else %>
 			<% unless user_signed_in? %>
-			<span class="hidden-xs pull-right"><%= link_to t(:reply, default: "Reply"), '#', data: {toggle: "modal", target: "#login-modal"}, class: 'btn btn-primary' %></span>
+			<span id="reply-button" class="hidden-xs pull-right"><%= link_to t(:reply, default: "Reply"), '#', data: {toggle: "modal", target: "#login-modal"}, class: 'btn btn-primary' %></span>
 			<% end %>
 		<% end -%>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,8 +9,13 @@
 			<%= render :partial => 'post', :collection => @posts %>
 		</table>
 
-
-		<% if user_signed_in? && !@topic.forum.allow_post_voting == true %>
+		<%
+		# NOTE: this is a bit of confusing logic- basically if the forum does not
+		# allow reply (post) voting, the form should be shown beneath all posts.
+		# This is handled here.  However, if there is post voting enabled,
+		# it will render immediately after the first post, within the partial.
+		%>
+		<% if user_signed_in? && @topic.forum.allow_post_voting == false %>
 		<div class="add-form">
 			<h4><%= t(:reply) %></h4>
 			<%#= error_messages_for :post -%>
@@ -25,7 +30,9 @@
 			<% end -%>
 			</div>
 		<% else %>
+			<% unless user_signed_in? %>
 			<span class="hidden-xs pull-right"><%= link_to t(:reply, default: "Reply"), '#', data: {toggle: "modal", target: "#login-modal"}, class: 'btn btn-primary' %></span>
+			<% end %>
 		<% end -%>
 
 	</div>

--- a/test/integration/browsing_user_ticket_flows_test.rb
+++ b/test/integration/browsing_user_ticket_flows_test.rb
@@ -8,12 +8,9 @@ class BrowsingUserTicketFlowsTest < ActionDispatch::IntegrationTest
     I18n.available_locales = [:en, :fr, :et]
     I18n.locale = :en
     logout(:user)
-#    Capybara.current_driver = Capybara.javascript_driver
-#    Capybara.default_wait_time = 30
   end
 
   def teardown
-#    logout(:user)
     Warden.test_reset!
   end
 

--- a/test/integration/browsing_user_ticket_flows_test.rb
+++ b/test/integration/browsing_user_ticket_flows_test.rb
@@ -1,0 +1,84 @@
+require 'integration_test_helper'
+include Warden::Test::Helpers
+
+class BrowsingUserTicketFlowsTest < ActionDispatch::IntegrationTest
+
+  def setup
+    Warden.test_mode!
+    I18n.available_locales = [:en, :fr, :et]
+    I18n.locale = :en
+    logout(:user)
+#    Capybara.current_driver = Capybara.javascript_driver
+#    Capybara.default_wait_time = 30
+  end
+
+  def teardown
+#    logout(:user)
+    Warden.test_reset!
+  end
+
+  test "a browsing user who is not registered should be able to create a private ticket via the web interface" do
+
+    # create new private ticket
+    visit '/en/topics/new/'
+
+    # a new user should be created
+    assert_difference('User.count', 1) do
+      assert_difference('Topic.count',1) do
+        fill_in('topic_user_email', with: 'test@test.com')
+        fill_in('topic[user][name]', with: 'John Smith')
+        fill_in('topic[name]', with: 'I got problems')
+        fill_in('post[body]', with: 'Please help me!!')
+        click_on('Start Discussion')
+      end
+    end
+
+    assert current_path == '/en/users/sign_in'
+
+  end
+
+  test "a browsing user who is registered should be able to create a private ticket via the web interface" do
+
+    # create new private ticket
+    visit '/en/topics/new/'
+
+    # A new user should not be created
+    assert_difference('User.count', 0) do
+      assert_difference('Topic.count',1) do
+        fill_in('topic_user_email', with: 'scott.miller@test.com')
+        fill_in('topic[user][name]', with: 'Scott Miller')
+        fill_in('topic[name]', with: 'I got problems')
+        fill_in('post[body]', with: 'Please help me!!')
+        click_on('Start Discussion')
+      end
+    end
+
+  end
+
+  test "a browsing user should be prompted to login from a public forum page" do
+
+    forums = [  "/en/community/3-public-forum/topics",
+                "/en/community/4-public-idea-board/topics",
+                "/en/community/5-public-q-a/topics" ]
+
+    forums.each do |forum|
+      visit forum
+      click_on "New Discussion"
+      assert find("div#login-modal").visible?
+    end
+  end
+
+  test "a browsing user should be prompted to login when clicking reply from a public discussion view" do
+
+    topics = [ "/en/topics/5-new-public-topic/posts",
+               "/en/topics/8-new-idea/posts",
+               "/en/topics/7-new-question/posts" ]
+
+    topics.each do |topic|
+      visit topic
+      click_on "Reply"
+      assert find("div#login-modal").visible?
+    end
+  end
+
+end

--- a/test/integration/forum_voting_test.rb
+++ b/test/integration/forum_voting_test.rb
@@ -7,8 +7,6 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     Warden.test_mode!
     I18n.available_locales = [:en, :fr, :et]
     I18n.locale = :en
-#    Capybara.current_driver = Capybara.javascript_driver
-#    Capybara.default_wait_time = 30
   end
 
   def teardown

--- a/test/integration/forum_voting_test.rb
+++ b/test/integration/forum_voting_test.rb
@@ -1,0 +1,62 @@
+require 'integration_test_helper'
+include Warden::Test::Helpers
+
+class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
+
+  def setup
+    Warden.test_mode!
+    I18n.available_locales = [:en, :fr, :et]
+    I18n.locale = :en
+#    Capybara.current_driver = Capybara.javascript_driver
+#    Capybara.default_wait_time = 30
+  end
+
+  def teardown
+    Warden.test_reset!
+  end
+
+  test "a logged in user should be able to vote on a topic from the topic index view" do
+
+    sign_in
+
+    visit "/en/community/3-public-forum/topics"
+    assert_difference('Topic.find(4).points') do
+      within first('div.topic-points') do
+        click_link "0"
+      end
+    end
+    visit "/en/community/3-public-forum/topics"
+    within ('tr#topic_4') do
+      assert page.has_content?("1")
+    end
+
+
+    visit "/en/community/4-public-idea-board/topics"
+    assert_difference('Topic.find(8).points') do
+      within first('div#post-vote-8') do
+        click_link "Upvote | 0"
+      end
+    end
+    visit "/en/community/4-public-idea-board/topics"
+    within first('a.topic-vote') do
+      assert page.has_content?("Upvote | 1")
+    end
+
+
+    visit "/en/community/5-public-q-a/topics"
+    assert_difference('Topic.find(7).points') do
+      within first('div#post-vote-7') do
+        click_link "Upvote | 0"
+      end
+    end
+    visit "/en/community/5-public-q-a/topics"
+    within first('div#post-vote-7') do
+      assert page.has_content?("Upvote | 1")
+    end
+  end
+
+  test "a logged in user should be able to vote on a reply from the topic detail view" do
+
+  end
+
+end

--- a/test/integration/forum_voting_test.rb
+++ b/test/integration/forum_voting_test.rb
@@ -24,7 +24,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
       end
     end
     visit "/en/community/3-public-forum/topics"
-    within ('tr#topic_4') do
+    within 'tr#topic_4' do
       assert page.has_content?("1")
     end
 

--- a/test/integration/search_flows_test.rb
+++ b/test/integration/search_flows_test.rb
@@ -10,8 +10,6 @@ class SearchFlowsTest < ActionDispatch::IntegrationTest
     # Build PG search
     PgSearch::Multisearch.rebuild(Doc)
     PgSearch::Multisearch.rebuild(Topic)
-#    Capybara.current_driver = Capybara.javascript_driver
-#    Capybara.default_wait_time = 30
   end
 
   def teardown
@@ -24,10 +22,7 @@ class SearchFlowsTest < ActionDispatch::IntegrationTest
 
     within('div#body-wrapper') do
       fill_in('search-field', with: 'public')
-      #find('span.glyphicon-search').click
-      #within 'div#main-content' do
-        find('button.btn-default').click
-      #end
+      find('button.btn-default').click
     end
 
     uri = URI.parse(current_url)

--- a/test/integration/search_flows_test.rb
+++ b/test/integration/search_flows_test.rb
@@ -1,0 +1,38 @@
+require 'integration_test_helper'
+
+class SearchFlowsTest < ActionDispatch::IntegrationTest
+
+  def setup
+
+    I18n.available_locales = [:en, :fr, :et]
+    I18n.locale = :en
+
+    # Build PG search
+    PgSearch::Multisearch.rebuild(Doc)
+    PgSearch::Multisearch.rebuild(Topic)
+#    Capybara.current_driver = Capybara.javascript_driver
+#    Capybara.default_wait_time = 30
+  end
+
+  def teardown
+
+  end
+
+  test "a browsing user should be able to search from the home page" do
+
+    visit '/en'
+
+    within('div#body-wrapper') do
+      fill_in('search-field', with: 'public')
+      #find('span.glyphicon-search').click
+      #within 'div#main-content' do
+        find('button.btn-default').click
+      #end
+    end
+
+    uri = URI.parse(current_url)
+    assert "#{uri.path}?#{uri.query}" == '/en/result?utf8=%E2%9C%93&q=public'
+
+  end
+
+end

--- a/test/integration/sign_in_flow_test.rb
+++ b/test/integration/sign_in_flow_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require 'integration_test_helper'
 include Warden::Test::Helpers
 
 class SignInFlowTest < ActionDispatch::IntegrationTest
@@ -9,20 +9,26 @@ class SignInFlowTest < ActionDispatch::IntegrationTest
     I18n.locale = :en
   end
 
+  teardown do
+    Warden.test_reset!
+  end
+
   test "a browser should be able to sign in and be shown the home page" do
-    get "/en/users/sign_in"
-    # user = assigns(:user)
-    post '/en/users/sign_in', 'user[email]' => 'scott.miller@test.com', 'user[password]' => '12345678'
-    follow_redirect!
-    assert_equal '/en', path
+    sign_in
+    assert_equal '/en', current_path
   end
 
   test "an admin should be able to sign in and be shown the admin page" do
+    sign_in_admin
+    assert_equal '/admin', path
+  end
+
+  # TODO: for some reason I could not get the admin login with the regular sign_in method to work
+  # The current path never changed from /en so I had to resort to doing it this way:
+  def sign_in_admin
     get "/en/users/sign_in"
-    # user = assigns(:user)
     post '/en/users/sign_in', 'user[email]' => 'admin@test.com', 'user[password]' => '12345678'
     follow_redirect!
-    assert_equal '/admin', path
   end
 
 end

--- a/test/integration/signed_in_user_ticket_flows_test.rb
+++ b/test/integration/signed_in_user_ticket_flows_test.rb
@@ -1,0 +1,141 @@
+require 'integration_test_helper'
+include Warden::Test::Helpers
+
+class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
+
+  def setup
+    Warden.test_mode!
+    I18n.available_locales = [:en, :fr, :et]
+    I18n.locale = :en
+#    Capybara.current_driver = Capybara.javascript_driver
+#    Capybara.default_wait_time = 30
+  end
+
+  def teardown
+    Warden.test_reset!
+  end
+
+  test "a signed in user should be able to create a private ticket via the web interface" do
+
+    # sign in user
+    sign_in
+
+    visit '/en'
+    visit '/en/topics/new/'
+
+    # make sure we get the signed in version
+    assert page.has_content?('Should this message be private?')
+
+    assert_difference('Topic.count', 1) do
+      choose('Only support can respond (creates a private ticket)')
+      fill_in('topic[name]', with: 'I got problems')
+      fill_in('post[body]', with: 'Please help me!!')
+      click_on('Start Discussion')
+    end
+
+    visit '/en/tickets/'
+    assert page.has_content?('Tickets')
+    assert page.has_content?("##{Topic.last.id}- I got problems")
+
+  end
+
+  test "a signed in user should be able to create a public topic via the web interface" do
+
+    # sign in user
+    sign_in
+
+    visit '/en'
+    visit '/en/topics/new/'
+
+    # make sure we get the signed in version
+    assert page.has_content?('Should this message be private?')
+
+    assert_difference('Topic.count', 1) do
+      choose('Responses can come from support or the community (recommended)')
+      select('Public Forum', from: "topic[forum_id]")
+      fill_in('topic[name]', with: 'I got problems')
+      fill_in('post[body]', with: 'Please help me!!')
+      click_on('Start Discussion')
+    end
+
+    visit '/en/community/3-public-forum/topics'
+    assert page.has_content?("I got problems")
+
+  end
+
+  test "a signed in user should be able to reply to a private ticket" do
+
+    sign_in
+
+    visit '/en'
+    visit '/en/tickets'
+
+    assert page.has_content?('#1- Private topic')
+    click_on('#1- Private topic')
+
+    assert current_path == '/en/ticket/1-private-topic'
+    assert_difference('Post.count', 1) do
+      fill_in "post_body", with: "This is my reply"
+      click_on "Post Reply"
+    end
+
+#    assert page.has_content?('This is my reply'), "Reply not found"
+
+  end
+
+  test "a logged in user should be prompted to create a new public topic" do
+
+    sign_in
+
+    forums = [  "/en/community/3-public-forum/topics",
+                "/en/community/4-public-idea-board/topics",
+                "/en/community/5-public-q-a/topics" ]
+
+    forums.each do |forum|
+      visit forum
+      click_on "New Discussion"
+      assert current_path == "/en/topics/new"
+    end
+
+  end
+
+  test "a logged in user should not see the reply button when viewing a public topic" do
+
+    sign_in
+
+    topics = [ "/en/topics/5-new-public-topic/posts",
+               "/en/topics/8-new-idea/posts",
+               "/en/topics/7-new-question/posts" ]
+
+    topics.each do |topic|
+      visit topic
+      assert !page.has_content?('Reply'), message: 'Reply button displayed when it shouldnt be'
+      assert page.has_content?('Type your response:')
+    end
+
+  end
+
+  test "a signed in user should be able to reply to a public topic" do
+
+    sign_in
+
+    topics = [ "/en/topics/5-new-public-topic/posts",
+               "/en/topics/8-new-idea/posts",
+               "/en/topics/7-new-question/posts" ]
+
+    topics.each do |topic|
+
+      visit topic
+
+      assert_difference('Post.count', 1) do
+        fill_in "post_body", with: "This is my reply"
+        click_on "Post Reply"
+      end
+
+      visit topic
+      assert page.has_content?('This is my reply'), "Reply not found"
+
+    end
+
+  end
+end

--- a/test/integration/signed_in_user_ticket_flows_test.rb
+++ b/test/integration/signed_in_user_ticket_flows_test.rb
@@ -7,8 +7,6 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     Warden.test_mode!
     I18n.available_locales = [:en, :fr, :et]
     I18n.locale = :en
-#    Capybara.current_driver = Capybara.javascript_driver
-#    Capybara.default_wait_time = 30
   end
 
   def teardown
@@ -17,13 +15,11 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
 
   test "a signed in user should be able to create a private ticket via the web interface" do
 
-    # sign in user
     sign_in
 
     visit '/en'
     visit '/en/topics/new/'
 
-    # make sure we get the signed in version
     assert page.has_content?('Should this message be private?')
 
     assert_difference('Topic.count', 1) do
@@ -41,13 +37,11 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
 
   test "a signed in user should be able to create a public topic via the web interface" do
 
-    # sign in user
     sign_in
 
     visit '/en'
     visit '/en/topics/new/'
 
-    # make sure we get the signed in version
     assert page.has_content?('Should this message be private?')
 
     assert_difference('Topic.count', 1) do
@@ -109,7 +103,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
 
     topics.each do |topic|
       visit topic
-      assert !page.has_content?('Reply'), message: 'Reply button displayed when it shouldnt be'
+      assert page.has_no_css?('#reply-button'), message: "Reply button displayed when it shouldnt be (url: #{topic})"
       assert page.has_content?('Type your response:')
     end
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+require "capybara/rails"
+
+class ActionDispatch::IntegrationTest
+  # Make the Capybara DSL available in all integration tests
+  include Capybara::DSL
+end
+
+def sign_in(email='scott.miller@test.com')
+  visit "/en/users/sign_in"
+  within first('div.login-form') do
+    fill_in("user[email]", with: email)
+    fill_in("user[password]", with: '12345678')
+    click_on('Sign in')
+  end
+end
+
+def sign_in_by_modal(email='scott.miller@test.com')
+  within("div#above-header") do
+    click_on "Sign in", wait: 30
+  end
+  within('div#login-modal') do
+    fill_in("user[email]", with: email)
+    fill_in("user[password]", with: '12345678')
+    click_on('Sign in')
+  end
+end
+
+def sign_out
+  logout(:user)
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
-  Settings.send_email = true
+  Settings.send_email = false
 end
 
 class ActionController::TestCase


### PR DESCRIPTION
This PR refactors the `_post` partial by moving to two partials one for admin and one for front-end.  This removed a lot of icky spagetti switching code and made it easier to resolve some issues related to trying to share one partial between two concerns.

I also merged in the integration testing branch and extended it, so thats included in this PR as well.

This PR fixes #73, #42 and #20 